### PR TITLE
add VCAL in DB interface

### DIFF
--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Fulltest.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Fulltest.py
@@ -1,5 +1,5 @@
 import os
-
+import sys
 import ROOT
 
 import AbstractClasses
@@ -431,6 +431,7 @@ class TestResult(GeneralTestResult):
                             VANA = DacParameters['vana']['Value'], 
                             VSH = DacParameters['vsh']['Value'],
                             VCOMP = DacParameters['vcomp']['Value'],
+                            VCAL = DacParameters['Vcal']['Value'],
                             VWLLPR = DacParameters['vwllpr']['Value'],
                             VWLLSH = DacParameters['vwllsh']['Value'],
                             VTRIM = DacParameters['vtrim']['Value'],


### PR DESCRIPTION
this is a fix for the DacParameters filling, not related to XRay stuff 
@macjohnny @veloxid @tommasoboccali 