### PR TITLE
Issue #62: Plot File Types

### DIFF
--- a/Analyse/AbstractClasses/GeneralTestResult.py
+++ b/Analyse/AbstractClasses/GeneralTestResult.py
@@ -71,6 +71,10 @@ class GeneralTestResult(object):
         self.SavePlotFile = True
         self.GzipSVG = TestResultEnvironmentObject.Configuration['GzipSVG']
         self.DefaultImageFormat = TestResultEnvironmentObject.Configuration['DefaultImageFormat'].strip().lower()
+        if TestResultEnvironmentObject.Configuration.has_key('AdditionalImageFormats'):
+            self.AdditionalImageFormats = TestResultEnvironmentObject.Configuration['AdditionalImageFormats'].strip().lower().split(',')
+        else:
+        	self.AdditionalImageFormats = ['root', 'pdf']
         if TestResultEnvironmentObject.Configuration.has_key('OverviewHTMLLink'):
             self.OverviewHTMLLink = TestResultEnvironmentObject.Configuration['OverviewHTMLLink']
         else:
@@ -115,7 +119,8 @@ class GeneralTestResult(object):
                 'Caption': '',
                 'ImageFile': '',
                 'Format': self.DefaultImageFormat,
-                'AdditionalFormats':['root','pdf'],
+                'AdditionalFormats':self.AdditionalImageFormats,
+                'ImageFilePDF':'',
             },
             # SubTest Results
             'SubTestResults': {},
@@ -495,6 +500,8 @@ class GeneralTestResult(object):
                 self.Canvas.SaveAs(self.GetPlotFileName())
                 for Suffix in self.ResultData['Plot']['AdditionalFormats']:
                 	self.Canvas.SaveAs(self.GetPlotFileName(Suffix))
+                	if Suffix == 'pdf':
+                		self.ResultData['Plot']['ImageFilePDF'] = self.GetPlotFileName()
                 self.ResultData['Plot']['Enabled'] = 1
                 self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
     '''
@@ -743,6 +750,8 @@ class GeneralTestResult(object):
                     {
                         '###FILENAME###': HtmlParser.MaskHTML(
                             RecursionRelativePath + os.path.basename(TestResultObject.ResultData['Plot']['ImageFile'])),
+                        '###PDFFILENAME###': HtmlParser.MaskHTML(
+                            RecursionRelativePath + os.path.basename(TestResultObject.ResultData['Plot']['ImageFilePDF'])),
                         '###IMAGELARGECONTAINERID###': HtmlParser.MaskHTML(
                             TestResultObject.Name + '_' + TestResultObject.Key),
                         '###MARGIN_TOP###': str(int(-800. / float(

--- a/Analyse/AbstractClasses/GeneralTestResult.py
+++ b/Analyse/AbstractClasses/GeneralTestResult.py
@@ -70,15 +70,18 @@ class GeneralTestResult(object):
         self.Enabled = True
         self.SavePlotFile = True
         self.GzipSVG = TestResultEnvironmentObject.Configuration['GzipSVG']
+        
         self.DefaultImageFormat = TestResultEnvironmentObject.Configuration['DefaultImageFormat'].strip().lower()
         if TestResultEnvironmentObject.Configuration.has_key('AdditionalImageFormats'):
             self.AdditionalImageFormats = TestResultEnvironmentObject.Configuration['AdditionalImageFormats'].strip().lower().split(',')
         else:
         	self.AdditionalImageFormats = ['root', 'pdf']
+        	
         if TestResultEnvironmentObject.Configuration.has_key('OverviewHTMLLink'):
             self.OverviewHTMLLink = TestResultEnvironmentObject.Configuration['OverviewHTMLLink']
         else:
             self.OverviewHTMLLink = None
+            
         # Path for current test to folder with root-files
         self.RawTestSessionDataPath = ''
 

--- a/Analyse/AbstractClasses/GeneralTestResult.py
+++ b/Analyse/AbstractClasses/GeneralTestResult.py
@@ -504,7 +504,7 @@ class GeneralTestResult(object):
                 for Suffix in self.ResultData['Plot']['AdditionalFormats']:
                 	self.Canvas.SaveAs(self.GetPlotFileName(Suffix))
                 	if Suffix == 'pdf':
-                		self.ResultData['Plot']['ImageFilePDF'] = self.GetPlotFileName()
+                		self.ResultData['Plot']['ImageFilePDF'] = self.GetPlotFileName(Suffix)
                 self.ResultData['Plot']['Enabled'] = 1
                 self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
     '''

--- a/Analyse/AbstractClasses/GeneralTestResult.py
+++ b/Analyse/AbstractClasses/GeneralTestResult.py
@@ -115,6 +115,7 @@ class GeneralTestResult(object):
                 'Caption': '',
                 'ImageFile': '',
                 'Format': self.DefaultImageFormat  # svg
+                'AdditionalFormats':['root','pdf'],
             },
             # SubTest Results
             'SubTestResults': {},
@@ -492,7 +493,10 @@ class GeneralTestResult(object):
         if self.SavePlotFile:
             if self.Canvas:
                 self.Canvas.SaveAs(self.GetPlotFileName())
-                self.Canvas.SaveAs(self.GetPlotFileName('root'))
+                for Suffix in self.ResultData['Plot']['AdditionalFormats']:
+                	self.Canvas.SaveAs(self.GetPlotFileName(Suffix))
+                self.ResultData['Plot']['Enabled'] = 1
+                self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
     '''
         Generate the filename including the full path to the plot file according to the format
     '''

--- a/Analyse/AbstractClasses/GeneralTestResult.py
+++ b/Analyse/AbstractClasses/GeneralTestResult.py
@@ -114,7 +114,7 @@ class GeneralTestResult(object):
                 'ROOTObject': None,
                 'Caption': '',
                 'ImageFile': '',
-                'Format': self.DefaultImageFormat  # svg
+                'Format': self.DefaultImageFormat,
                 'AdditionalFormats':['root','pdf'],
             },
             # SubTest Results

--- a/Analyse/Configuration/SystemConfiguration.cfg
+++ b/Analyse/Configuration/SystemConfiguration.cfg
@@ -2,6 +2,7 @@
 AnalysisRevision = 1
 GenerateResultData = 1
 DefaultImageFormat = svg
+AdditionalImageFormats = root,pdf
 GzipSVG = 0
 UseGlobalDatabase =  0
 DatabaseType = 

--- a/Analyse/HTML/TestResult/TestResultTemplate.css
+++ b/Analyse/HTML/TestResult/TestResultTemplate.css
@@ -189,8 +189,9 @@
 		right:0px;
 		bottom:0px;
 		z-index:10;
-		padding:5px;
+		padding:10px;
 		cursor:pointer;
+		background:#fff;
 	}
 	#Page #ContentWrap #Content .ResultData .Plot .LargeImageContainer .OpenInNewWindowLinkWrap
 	{

--- a/Analyse/HTML/TestResult/TestResultTemplate.css
+++ b/Analyse/HTML/TestResult/TestResultTemplate.css
@@ -171,6 +171,7 @@
 	}
 	#Page #ContentWrap #Content .ResultData .Plot .LargeImageContainer .ImageTitle
 	{
+		
 		position:absolute;
 		width:100%;
 		text-align:center;
@@ -180,6 +181,16 @@
 		/*max-width:90%;
 		max-height:90%;*/
 		width:800px;
+	}
+	#Page #ContentWrap #Content .ResultData .Plot .LargeImageContainer .PDFLink
+	{
+		position:absolute;
+		display:block;
+		right:0px;
+		bottom:0px;
+		z-index:10;
+		padding:5px;
+		cursor:pointer;
 	}
 	#Page #ContentWrap #Content .ResultData .Plot .LargeImageContainer .OpenInNewWindowLinkWrap
 	{

--- a/Analyse/HTML/TestResult/TestResultTemplate.html
+++ b/Analyse/HTML/TestResult/TestResultTemplate.html
@@ -67,7 +67,7 @@
 															<h4 class="ImageTitle">###TITLE###</h4>
 															<img class="ImageLarge" src="###FILENAME###"  alt="Plot"/>
 														</a>
-														<a class="PDFLink" src="###PDFFILENAME###">&gt; PDF Version</a>
+														<a class="PDFLink" href="###PDFFILENAME###" target="_blank">&gt; PDF Version</a>
 													</div>
 												<!-- ###PLOT_IMAGE### -->
 											</div>

--- a/Analyse/HTML/TestResult/TestResultTemplate.html
+++ b/Analyse/HTML/TestResult/TestResultTemplate.html
@@ -67,6 +67,7 @@
 															<h4 class="ImageTitle">###TITLE###</h4>
 															<img class="ImageLarge" src="###FILENAME###"  alt="Plot"/>
 														</a>
+														<a class="PDFLink" src="###PDFFILENAME###">&gt; PDF Version</a>
 													</div>
 												<!-- ###PLOT_IMAGE### -->
 											</div>

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/BareAliveSummary/BareAliveSummary.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/BareAliveSummary/BareAliveSummary.py
@@ -100,8 +100,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
         self.ResultData['Plot']['Format'] = 'png'
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'bare BBmap'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/BareBBSummary/BareBBSummary.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/BareBBSummary/BareBBSummary.py
@@ -101,8 +101,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
         self.ResultData['Plot']['Format'] = 'png'
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'bare BBmap'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBMap/BareBBMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBMap/BareBBMap.py
@@ -113,11 +113,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             #for column in range(self.nCols): #Column
             #    for row in range(self.nRows): #Row
             #print 'content', column, row, self.ResultData['Plot']['ROOTObject'].GetBinContent(column, row), self.ResultData['Plot']['ROOTObject'].GetXaxis().GetBinCenter( column ), self.ResultData['Plot']['ROOTObject'].GetYaxis().GetBinCenter( row );
-
-        
-            if self.SavePlotFile:
-                self.Canvas.SaveAs(self.GetPlotFileName())
-                self.ResultData['Plot']['Enabled'] = 1
-                self.Title = 'Bare BBMap: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
-                self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+            
+            self.Title = 'Bare BBMap: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
+                
+            self.SaveCanvas()    
+            

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBScan/BareBBScan.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBScan/BareBBScan.py
@@ -40,12 +40,11 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             #            for column in range(self.nCols): #Column
             #                for row in range(self.nRows): #Row
             #                    self.HasAddressDecodingProblem(column, row)
-
-        
-            if self.SavePlotFile:
-                self.ResultData['Plot']['Format'] = 'png'
-                self.Canvas.SaveAs(self.GetPlotFileName())
-                self.ResultData['Plot']['Enabled'] = 1
-                self.Title = 'Bare BBScan: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
-                self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+            
+            self.Title = 'Bare BBScan: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
+                
+            
+			self.ResultData['Plot']['Format'] = 'png'
+			self.SaveCanvas()
+			
 

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBWidth/BareBBWidth.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBWidth/BareBBWidth.py
@@ -66,11 +66,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
 
 
-            if self.SavePlotFile:
-                self.Canvas.SaveAs(self.GetPlotFileName())
-                self.ResultData['Plot']['Enabled'] = 1
-                self.Title = 'Bare BBWidth: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
-                self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+            self.Title = 'Bare BBWidth: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
+            self.SaveCanvas()
 #        self.ResultData['KeyValueDictPairs']['AddressDecodingProblems'] = {'Value':self.AddressProblemList, 'Label':'Address Decoding Problems', }
 #        self.ResultData['KeyValueDictPairs']['NAddressDecodingProblems'] = {'Value':len(self.AddressProblemList), 'Label':'N Address DecodingProblems', }
 #        self.ResultData['KeyList'].append('NAddressDecodingProblems')

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BarePixelMap/BarePixelMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BarePixelMap/BarePixelMap.py
@@ -74,8 +74,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                     self.ResultData['KeyValueDictPairs']['DeadPixels'] = {'Value':self.DeadPixelList, 'Label':'Dead Pixels'}
                     self.ResultData['KeyValueDictPairs']['NDeadPixels'] = { 'Value':len(self.DeadPixelList), 'Label':'N Dead Pixels'}
 
-                    if self.SavePlotFile:
-                        self.Canvas.SaveAs(self.GetPlotFileName())
-                        self.ResultData['Plot']['Enabled'] = 1
-                        self.Title = 'BarePixelMap: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
-                        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+                    self.Title = 'BarePixelMap: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
+                    self.SaveCanvas()

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/AddressLevelOverview/AddressLevels/AddressLevels.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/AddressLevelOverview/AddressLevels/AddressLevels.py
@@ -27,6 +27,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             PlotContent = f.write(PlotContent)
             f.close()
             
-        self.ResultData['Plot']['Enabled'] = 1
         self.Title = 'Address Levels: C{ChipNo}'.format(ChipNo=self.Attributes['ChipNo'])
+        self.ResultData['Plot']['Enabled'] = 1
         self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/BumpBondingMap/BumpBondingMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/BumpBondingMap/BumpBondingMap.py
@@ -90,13 +90,9 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
         self.ResultData['Plot']['Format'] = 'png'
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        #self.Canvas.SaveAs(self.GetPlotFileName()+'.root')
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Bump Bonding Map'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        
     def UpdatePlot(self, chipNo, col, row, value):
         result = value
         if chipNo < 8:

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/AddressDecoding/AddressDecoding.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/AddressDecoding/AddressDecoding.py
@@ -32,11 +32,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                 for row in range(self.nRows): #Row
                     self.HasAddressDecodingProblem(column, row)
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Address Decoding: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
         self.ResultData['KeyValueDictPairs']['AddressDecodingProblems'] = {'Value':self.AddressProblemList, 'Label':'Address Decoding Problems', }
         self.ResultData['KeyValueDictPairs']['NAddressDecodingProblems'] = {'Value':len(self.AddressProblemList), 'Label':'N Address DecodingProblems', }
         self.ResultData['KeyList'].append('NAddressDecodingProblems')

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/AddressLevels/AddressLevels.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/AddressLevels/AddressLevels.py
@@ -35,8 +35,7 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].Draw();
             
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())      
+        self.SaveCanvas()      
         self.ResultData['Plot']['Enabled'] = 1
         self.Title = 'Address Levels: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
         self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/BumpBonding/BumpBonding.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/BumpBonding/BumpBonding.py
@@ -66,11 +66,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.Cut.SetLineColor(ROOT.kRed)
             self.Cut.Draw('PL')
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Bump Bonding: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
         self.ResultData['KeyValueDictPairs']['Mean']['Value'] = round(mean, 2)
         self.ResultData['KeyList'].append('Mean')
         self.ResultData['KeyValueDictPairs']['RMS']['Value'] = round(rms, 2)

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/BumpBondingProblems/BumpBondingProblems.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/BumpBondingProblems/BumpBondingProblems.py
@@ -72,12 +72,9 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].SaveAs(self.GetPlotFileName() + '.cpp')
 
         self.ResultData['Plot']['ROOTObject2'] = self.ResultData['Plot']['ROOTObject'].Clone(self.GetUniqueID())
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
+        self.SaveCanvas()
 
-        self.ResultData['Plot']['Enabled'] = 1
         self.Title = 'Bump Bonding Problems: C{ChipNo}'.format(ChipNo=self.chipNo)
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
         self.ResultData['KeyValueDictPairs']['DeadBumps']['Value'] = self.DeadBumpList
         self.ResultData['KeyValueDictPairs']['NDeadBumps']['Value'] = len(self.DeadBumpList)
         self.ResultData['KeyList'].append('NDeadBumps')

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationGain/PHCalibrationGain.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationGain/PHCalibrationGain.py
@@ -162,10 +162,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             if over:
                 self.ResultData['KeyValueDictPairs']['over'] = {'Value': '{0:1.2f}'.format(over), 'Label': '>='}
                 self.ResultData['KeyList'].append('over')
-            if self.SavePlotFile:
-                self.Canvas.SaveAs(self.GetPlotFileName())
-            self.ResultData['Plot']['Enabled'] = 1
-            self.ResultData['Plot']['Caption'] = 'PH Calibration: Gain (Vcal/ADC)'
-            self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+                
+            self.SaveCanvas()
+			self.ResultData['Plot']['Caption'] = 'PH Calibration: Gain (Vcal/ADC)'
             ROOT.gPad.SetLogy(0)
 

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationGain/PHCalibrationGain.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationGain/PHCalibrationGain.py
@@ -164,6 +164,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                 self.ResultData['KeyList'].append('over')
                 
             self.SaveCanvas()
-			self.ResultData['Plot']['Caption'] = 'PH Calibration: Gain (Vcal/ADC)'
+            self.ResultData['Plot']['Caption'] = 'PH Calibration: Gain (Vcal/ADC)'
             ROOT.gPad.SetLogy(0)
 

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationGainMap/PHCalibrationGainMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationGainMap/PHCalibrationGainMap.py
@@ -22,9 +22,7 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].Draw("colz")
         else:
             raise Exception('PHCalibrationGainMap - ROOT Object does not exists!')
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'PH Calibration Gain Map'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        
 #

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationParameter1/PHCalibrationParameter1.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationParameter1/PHCalibrationParameter1.py
@@ -52,10 +52,7 @@ class TestResult(GeneralTestResult):
         if self.verbose:
             print self.ResultData['KeyValueDictPairs']
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
+        self.SaveCanvas()
 
-        self.ResultData['Plot']['Enabled'] = 1
         self.ResultData['Plot']['Caption'] = 'Parameter1'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
         ROOT.gPad.SetLogy(0)

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationPedestal/PHCalibrationPedestal.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PHCalibrationPedestal/PHCalibrationPedestal.py
@@ -110,12 +110,9 @@ class TestResult(GeneralTestResult):
         line2.SetLineWidth(3)
         line2.SetLineStyle(2)
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'PH Calibration: Pedestal (Vcal)'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        
         self.ResultData['KeyValueDictPairs'] = {
             'N': {
                 'Value': '{0:1.0f}'.format(IntegralPedestal),

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PixelMap/PixelMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/PixelMap/PixelMap.py
@@ -65,12 +65,9 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].GetZaxis().CenterTitle();
             self.ResultData['Plot']['ROOTObject'].Draw('colz');
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Pixel Map: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        
     def CheckPixelAlive(self):
         for column in range(self.nCols): #Column
             for row in range(self.nRows): #Row

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/SCurveWidths/SCurveWidths.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/SCurveWidths/SCurveWidths.py
@@ -141,8 +141,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['KeyValueDictPairs']['over'] = {'Value':'{0:1.2f}'.format(over), 'Label':'>='}
             self.ResultData['KeyList'].append('over')
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'S-Curve widths: Noise (e^{-})'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TemperatureCalibration/TemperatureCalibration.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TemperatureCalibration/TemperatureCalibration.py
@@ -28,12 +28,9 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].Draw("A*");
 
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Address Levels: C{ChipNo}'.format(ChipNo=self.ParentObject.Attributes['ChipNo'])
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        
     def analyse(self, directoryName, chipId)
         tl = ROOT.TLatex()
 

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBitMap/TrimBitMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBitMap/TrimBitMap.py
@@ -39,8 +39,6 @@ class TestResult(GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
             self.ResultData['Plot']['ROOTObject'].Draw('colz')
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Trim Bit Map'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBitProblems/TrimBitProblems.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBitProblems/TrimBitProblems.py
@@ -46,11 +46,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].Draw('colz');
 
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Trim Bit Problems'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
         self.ResultData['KeyValueDictPairs'] = {
             'DeadTrimbits': {
                 'Value':self.DeadTrimbitsList,

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBitTest/TrimBitTest.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBitTest/TrimBitTest.py
@@ -61,8 +61,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             Legend.Draw()
 
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Trim Bit Test'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBits/TrimBitParameters/TrimBitParameters.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBits/TrimBitParameters/TrimBitParameters.py
@@ -61,8 +61,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             }
         }
         self.ResultData['KeyList'] = ['mu', 'sigma']
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Trim Bits - Trim '+self.Attributes['TrimValue']
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBits/TrimBits.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/TrimBits/TrimBits.py
@@ -99,8 +99,6 @@ class TestResult(GeneralTestResult):
         }
         self.ResultData['KeyList'] = ['mu', 'sigma']
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Trim Bits'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/VcalThresholdTrimmed/VcalThresholdTrimmed.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/VcalThresholdTrimmed/VcalThresholdTrimmed.py
@@ -114,11 +114,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                 for row in range(self.nRows):  # Row
                     self.HasThresholdDefect(column, row)
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.Title = 'Vcal Threshold Trimmed'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
         self.ResultData['KeyValueDictPairs']['TrimProblems'] = { 'Value':self.ThrDefectList, 'Label':'Trim Problems'}
         self.ResultData['KeyValueDictPairs']['NTrimProblems'] = { 'Value':len(self.ThrDefectList), 'Label':'N Trim Problems'}
         self.ResultData['KeyList'].append('NTrimProblems')

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/VcalThresholdUntrimmed/VcalThresholdUntrimmed.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/VcalThresholdUntrimmed/VcalThresholdUntrimmed.py
@@ -70,8 +70,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].Draw('colz');
 
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'Vcal Threshold Untrimmed'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/IVCurve/IVCurve.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/IVCurve/IVCurve.py
@@ -225,8 +225,6 @@ class TestResult(GeneralTestResult):
                 recalculatedCurrentAtVoltage150V)
             self.ResultData['KeyValueDictPairs']['recalculatedCurrentVariation']['Value'] = '{0:1.2f}'.format(
                 recalculatedCurrentVariation)
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'I-V-Curve'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Temperature/Temperature.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Temperature/Temperature.py
@@ -260,9 +260,6 @@ class TestResult(GeneralTestResult):
         }
         self.ResultData['KeyList'] = ['Temperature', 'Duration']
         self.createTemperaturePlot()
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'Temperature'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/VcalThreshold/VcalThreshold.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/VcalThreshold/VcalThreshold.py
@@ -100,8 +100,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
         self.ResultData['Plot']['Format'] = 'png'
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'Vcal Threshold'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateDColEfficiencyModule/Chips/Chip/Chip.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateDColEfficiencyModule/Chips/Chip/Chip.py
@@ -83,6 +83,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'] = HighRateDColEfficiency.ResultData['Plot']['ROOTObject'].Clone(self.GetUniqueID())
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
         if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
+             self.SaveCanvas()
         self.ResultData['Plot']['Enabled'] = 0
         self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateDColEfficiencyModule/Chips/Chip/HighRateDColEfficiency/HighRateDColEfficiency.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateDColEfficiencyModule/Chips/Chip/HighRateDColEfficiency/HighRateDColEfficiency.py
@@ -72,11 +72,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw()
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        self.SaveCanvas()
+        
         #self.ResultData["KeyValueDictPairs"] = {
         #    "Rate" : {
         #        "Value" : 0,

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateDColEfficiencyModule/Chips/Chip/HighRateDColEfficiencySigma/HighRateDColEfficiencySigma.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateDColEfficiencyModule/Chips/Chip/HighRateDColEfficiencySigma/HighRateDColEfficiencySigma.py
@@ -41,11 +41,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw()
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        self.SaveCanvas()
+        
         #self.ResultData["KeyValueDictPairs"] = {
         #    "Rate" : {
         #        "Value" : 0,

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateDColEfficiencyModule/ModuleSigma/ModuleSigma.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateDColEfficiencyModule/ModuleSigma/ModuleSigma.py
@@ -57,11 +57,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw()
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        self.SaveCanvas()
+        
         #self.ResultData["KeyValueDictPairs"] = {
         #    "Rate" : {
         #        "Value" : 0,

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/Chips/Chip/Chip.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/Chips/Chip/Chip.py
@@ -84,6 +84,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'] = HighRateEffMap.ResultData['Plot']['ROOTObject'].Clone(self.GetUniqueID())
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
         if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
+             self.SaveCanvas()
         self.ResultData['Plot']['Enabled'] = 0
         self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/Chips/Chip/HighRateEffDist/HighRateEffDist.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/Chips/Chip/HighRateEffDist/HighRateEffDist.py
@@ -38,7 +38,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw()
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/Chips/Chip/HighRateEffMap/HighRateEffMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/Chips/Chip/HighRateEffMap/HighRateEffMap.py
@@ -41,11 +41,8 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        self.SaveCanvas()
+        
         self.ResultData["KeyValueDictPairs"] = {
             "Triggers" : {
                 "Value" : int(ntrig.GetVal()),

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/ModuleDist/ModuleDist.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/ModuleDist/ModuleDist.py
@@ -47,7 +47,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         # Add the histogram to the result of this test
         self.ResultData['Plot']['ROOTObject'] = hist
         self.ResultData['Plot']['ROOTObject'].Draw()
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/ModuleMap/ModuleMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRateEfficiencyModule/ModuleMap/ModuleMap.py
@@ -60,7 +60,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         # Add the histogram to the result of this test
         self.ResultData['Plot']['ROOTObject'] = hist
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/Chip.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/Chip.py
@@ -147,6 +147,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'] = HighRatePixelMap.ResultData['Plot']['ROOTObject'].Clone(self.GetUniqueID())
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
         if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
+             self.SaveCanvas()
         self.ResultData['Plot']['Enabled'] = 0
         self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePHDist/HighRatePHDist.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePHDist/HighRatePHDist.py
@@ -40,6 +40,6 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(2.5)
         self.ResultData['Plot']['ROOTObject'].Draw()
         if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
+             self.SaveCanvas()
         self.ResultData['Plot']['Enabled'] = 1
         self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePHMap/HighRatePHMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePHMap/HighRatePHMap.py
@@ -38,7 +38,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePHWidthMap/HighRatePHWidthMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePHWidthMap/HighRatePHWidthMap.py
@@ -38,7 +38,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePixelMap/HighRatePixelMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePixelMap/HighRatePixelMap.py
@@ -39,7 +39,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePixelMapDist/HighRatePixelMapDist.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/Chips/Chip/HighRatePixelMapDist/HighRatePixelMapDist.py
@@ -39,7 +39,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
         self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
         self.ResultData['Plot']['ROOTObject'].Draw()
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PHDist/PHDist.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PHDist/PHDist.py
@@ -47,7 +47,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         # Add the histogram to the result of this test
         self.ResultData['Plot']['ROOTObject'] = hist
         self.ResultData['Plot']['ROOTObject'].Draw()
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PHMap/PHMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PHMap/PHMap.py
@@ -58,7 +58,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         # Add the histogram to the result of this test
         self.ResultData['Plot']['ROOTObject'] = hist
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PHWidthMap/PHWidthMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PHWidthMap/PHWidthMap.py
@@ -58,7 +58,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         # Add the histogram to the result of this test
         self.ResultData['Plot']['ROOTObject'] = hist
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PixelMap/PixelMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PixelMap/PixelMap.py
@@ -64,7 +64,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         # Add the histogram to the result of this test
         self.ResultData['Plot']['ROOTObject'] = hist
         self.ResultData['Plot']['ROOTObject'].Draw("colz")
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PixelMapDist/PixelMapDist.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/HighRateTest/HighRatePixelMapModule/PixelMapDist/PixelMapDist.py
@@ -80,7 +80,5 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         # Add the histogram to the result of this test
         self.ResultData['Plot']['ROOTObject'] = hist
         self.ResultData['Plot']['ROOTObject'].Draw()
-        if self.SavePlotFile:
-             self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Temperature/Temperature.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Temperature/Temperature.py
@@ -117,11 +117,8 @@ class TestResult(GeneralTestResult):
         print fileHandlePath
         self.analyseTemp(fileHandlePath + '/temperature.log')
         if self.verbose: raw_input('Press enter')
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         self.ResultData['Plot']['Caption'] = 'Temperature'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        
     def CustomWriteToDatabase(self, ParentID):
         pass

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/BAK/FluorescenceSpectrum/FluorescenceSpectrum.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/BAK/FluorescenceSpectrum/FluorescenceSpectrum.py
@@ -309,16 +309,12 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitle('number of entries #')
             self.ResultData['Plot']['ROOTObject'].Draw();
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         if self.Attributes.has_key('Target'):
             self.Title = 'Fluorescence Spectrum for %s'%(self.Attributes['Target'])
         else:
             self.Title = 'Fluorescence Spectrum'
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-        pass
-
+        
 #        '''
 #		#hg
 #		self.ResultData['Plot']['ROOTObject_hGain'] = ROOT.TH1D(self.GetUniqueID(), "", 300, -2.0, 5.5)  # hGain

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/Chips_Xray/Chip_Xray/Xray_Calibration_Chip/Xray_Calibration_Chip.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/Chips_Xray/Chip_Xray/Xray_Calibration_Chip/Xray_Calibration_Chip.py
@@ -61,10 +61,7 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
             self.ResultData['Plot']['ROOTObject'].Draw('APL')
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-
+        self.SaveCanvas()
+        
         self.ResultData['KeyList'] = ['Slope', 'Offset']
         self.ResultData['KeyValueDictPairs'] = {'Slope': slope,'Offset': offset,'chi2': chi2}

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/Chips_Xray/Chip_Xray/Xray_HitMap_Chip/Xray_HitMap_Chip.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/Chips_Xray/Chip_Xray/Xray_HitMap_Chip/Xray_HitMap_Chip.py
@@ -67,10 +67,7 @@ class TestResult(GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
             self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
         if self.verbose:
             tag = self.Name + ": Done"
             print "".ljust(len(tag), '=')+'\n'

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/Chips_Xray/Chip_Xray/Xray_Target_Chip/Xray_Target_Chip.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/Chips_Xray/Chip_Xray/Xray_Target_Chip/Xray_Target_Chip.py
@@ -70,10 +70,7 @@ class TestResult(GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
             self.ResultData['Plot']['ROOTObject'].Draw('')
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
         self.ResultData['KeyList'] = ['Center', 'TargetEnergy', 'TargetNElectrons', 'Chi2PerNDF','Rate']
         self.ResultData['KeyValueDictPairs'] = {'Center': center, 'TargetEnergy': energy,
                                                 'TargetNElectrons': n_electrons, 'Chi2PerNDF': chi2,'Rate':rate,

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/FluorescenceTargetModule/FluorescenceTargetROC/FluorescenceTargetROC.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/FluorescenceTargetModule/FluorescenceTargetROC/FluorescenceTargetROC.py
@@ -590,15 +590,11 @@ class TestResult(GeneralTestResult):
             self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitle('number of entries #')
             self.ResultData['Plot']['ROOTObject'].Draw()
 
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
+        self.SaveCanvas()
         if self.Attributes.has_key('Target'):
             self.Title = '%s Spectrum ROC %i' % (self.Attributes['Target'], self.Attributes['ChipNo'])
         else:
             self.Title = 'Spectrum ROC %i' % (self.Attributes['ChipNo'])
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-        pass
         if self.verbose:
             print 'done'
         # print self.ResultData['KeyValueDictPairs']

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/VcalCalibrationModule/VcalCalibrationROC/VcalCalibrationROC.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/VcalCalibrationModule/VcalCalibrationROC/VcalCalibrationROC.py
@@ -172,7 +172,5 @@ class TestResult(GeneralTestResult):
         }
         self.ResultData['KeyList'] = ['Slope', 'Offset']
         self.ResultData['Plot']['ROOTObject'].Draw("APL")
-        if self.SavePlotFile:
-            self.Canvas.SaveAs(self.GetPlotFileName())
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+        self.SaveCanvas()
+        


### PR DESCRIPTION
additional images are saved according to SytemConfiguration.cfg: AdditionalImageFormats
moreover, the default behaviour can be overridden for each plot by setting e.g. 
self.ResultData['Plot']['AdditionalFormats'] = ['root'] #only save root files, no PDF
and now there is also a pdf-file link in the zoom-view of a plot (lower-right corner)
