### PR TITLE
fix chi2/ndf for linear fit in vcal calibration

### DIFF
--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/VcalCalibrationModule/VcalCalibrationROC/VcalCalibrationROC.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XrayCalibration/VcalCalibrationModule/VcalCalibrationROC/VcalCalibrationROC.py
@@ -163,10 +163,10 @@ class TestResult(GeneralTestResult):
                 'Sigma': round(fit.GetParError(0), 3),
             },
             'chi2': {
-                'Value': round(fit.GetParameter(0), 3),
+                'Value': round(fit.GetChisquare() / fit.GetNDF(), 3),
                 'Label': 'Chi2',
                 'Unit': 'per NDF',
-                'Sigma': round(fit.GetChisquare() / fit.GetNDF(), 3),
+                'Sigma': 0,
             },
 
         }


### PR DESCRIPTION
Fix a bug which caused chi2/ndf to have the same value than the offset of the line in Vcal calibration.
This fixes #78 but #9 still remains open, I will try to improve the calculation of the error.