### PR TITLE
Update BumpBondingBB2 cut and fixing  when one histogram does not exist

### DIFF
--- a/Analyse/AbstractClasses/Helper/HistoGetter.py
+++ b/Analyse/AbstractClasses/Helper/HistoGetter.py
@@ -50,5 +50,9 @@ def get_histo(rootfile,name,rocNo = None):
             all_names = []
             for i in dir.GetListOfKeys():
                 all_names.append(i.GetName())
-            raise NameError("Didn't found any possible candidate for the Xray spectrum: {Name} in {Names}".format(Name=name,Names=all_names))
+            try:
+                raise NameError("Didn't found any possible candidate for the Xray spectrum: {Name} in {Names}".format(Name=name,Names=all_names))
+            except NameError:
+                print 'The histogram ',histoname , ' was not found'
+
     return histo

--- a/Analyse/Configuration/Software/pxar.cfg
+++ b/Analyse/Configuration/Software/pxar.cfg
@@ -20,15 +20,16 @@ dir = ./
 
 #BareModuleTest.Chips.Chip
 [BareBBMap]
-BareBBMap: BareBBMap.BBtestMap_C%d
+BareBBMap: BB2.BBtestMap_C%d_V0
 #BareBBMap: BareBBMap.BBtestMap_C%d_V0
 
 [BareBBWidth]
-BareBBWidth: BareBBMap.CalsVthrPlateauWidth_C%d
+BareBBWidth: BB2.CalsVthrPlateauWidth_C%d_V0
 #BareBBWidth: BareBBMap.BareBBWidth_C%d_V0
 
 [BareBBScan]
-BareBBScan: BareBBMap.h22_C%d
+BareBBScan: BB2.N_VthrComp_C%d_V0
+
 #BareBBScan: BareBBMap.h22_C%d_V0
 
 #Fulltest.Chips.Chip
@@ -36,7 +37,7 @@ BareBBScan: BareBBMap.h22_C%d
 AddressDecoding: PixelAlive.AddressDecodingTest_C%d_V0
 
 [DigitalCurrent]
-DigitalCurrent: HD
+DigitalCurrent:HD
 
 [DigChipCurrent]
 DigitalCurrent: BumpBonding.hd_C%d

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBMap/BareBBMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBMap/BareBBMap.py
@@ -28,6 +28,16 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         print 'Inside BareBBMap ChipNo: ', ChipNo
         print 'and the histname: ', histname
 
+
+
+        # Calculate the cut from BareBBwidth distribution
+        #['KeyValueDictPairs']['thrCutBB2Map']['Value'] 
+        #        self.ParentObject.ResultData['SubTestResults']['BumpBonding'].ResultData['KeyValueDictPairs']['Mean']['Value']
+        #print '====Access: Cut Value from BBWidth',self.ParentObject.ResultData['SubTestResults']['BareBBWidth'].ResultData['KeyValueDictPairs']['thrCutBB2Map']['Value']
+        plWidthCutVal = self.ParentObject.ResultData['SubTestResults']['BareBBWidth'].ResultData['KeyValueDictPairs']['thrCutBB2Map']['Value']
+        print 'Used Width Cut ',plWidthCutVal
+
+
         #        histname = self.HistoDict.get(self.NameSingle,'BareBBScan')
 
         if self.HistoDict.has_option(self.NameSingle,'BareBBMap'):
@@ -78,7 +88,11 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                             if iBegin == 0:
                                 iBegin = ybin; # begin of plateau
                         
-                    if iEnd - iBegin < 35: #hard-coded CUT
+                    endCont = self.ResultData['Plot']['ROOTObject_Scan'].GetYaxis().GetBinUpEdge(iEnd);
+                    beginCont = self.ResultData['Plot']['ROOTObject_Scan'].GetYaxis().GetBinUpEdge(iBegin);
+
+                    if endCont - beginCont < plWidthCutVal:
+                    #if iEnd - iBegin < plWidthCutVal: #coming from the analysis of PlWidth distribution
                         ++nMissing;
                         print 'Missing Bump at raw col:', int(ibinCenter/80), int(ibinCenter%80);
                         # with weight 2 to draw it as red

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBWidth/BareBBWidth.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBWidth/BareBBWidth.py
@@ -1,4 +1,5 @@
 import ROOT
+import math
 import AbstractClasses.Helper.HistoGetter as HistoGetter
 import AbstractClasses
 class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
@@ -9,6 +10,9 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.Attributes['TestedObjectType'] = 'CMSPixel_QualificationGroup_Fulltest_ROC'
         self.AddressProblemList = set()
         self.chipNo = self.ParentObject.Attributes['ChipNo']
+        #self.CutList = set()
+        self.cut = 0
+        self.ResultData['KeyValueDictPairs']['thrCutBB2Map'] = {'Value': self.cut, 'Label': 'thrCutBB2'}
 
 
     def PopulateResultData(self):
@@ -26,15 +30,56 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 #        histname = self.ParentObject.ParentObject.ParentObject.HistoDict.get(self.NameSingle,'BareBBWidth')        
 #        histname = self.ParentObject.ParentObject.ParentObject.HistoDict.get(self.NameSingle,'BBtestMap')
 
-        print 'Inside BareBBWidth ChipNo: ', ChipNo
-        print 'and the histname: ', histname
+        #print 'Inside BareBBWidth ChipNo: ', ChipNo
+        #print 'and the histname: ', histname
 
         if self.HistoDict.has_option(self.NameSingle,'BareBBWidth'):
             histname = self.HistoDict.get(self.NameSingle,'BareBBWidth')            
             object = HistoGetter.get_histo(self.ParentObject.ParentObject.FileHandle, histname, rocNo = ChipNo)
-            self.ResultData['Plot']['ROOTObject']  = object.Clone(self.GetUniqueID())
-        
+            self.ResultData['Plot']['ROOTObject']  = object.Clone(self.GetUniqueID())       
+#
+#  Find PlateauSize cut to define the number of active/missing/inefficient bump-bonding
+#            
+
+            cutmax = 45
+            maxbin = self.ResultData['Plot']['ROOTObject'].GetMaximumBin()                
+            ymax = self.ResultData['Plot']['ROOTObject'].GetBinContent( maxbin )
+            xmax = self.ResultData['Plot']['ROOTObject'].GetBinCenter( maxbin )
+            y50 = 0.5*ymax
+            sigma = self.ResultData['Plot']['ROOTObject'].GetRMS()
+            xi = 0.
+            xj = 0.
+            ni = 0.
+            nj = 0.
             
+            #print '"====== !!! max ', ymax, ' at ',xmax, ' and sigma: ', sigma               
+            for ii in range (maxbin,1,-2):
+                jj = ii -2
+                print 'ii jj',ii,jj,' ',self.ResultData['Plot']['ROOTObject'].GetBinContent(jj),self.ResultData['Plot']['ROOTObject'].GetBinContent(ii)
+                if (self.ResultData['Plot']['ROOTObject'].GetBinContent(jj) < y50) and (self.ResultData['Plot']['ROOTObject'].GetBinContent(ii) >= y50):
+                    print 'aqui ',ii, ' - - ',jj,'',y50
+                    ni = self.ResultData['Plot']['ROOTObject'].GetBinContent(ii)
+                    nj = self.ResultData['Plot']['ROOTObject'].GetBinContent(jj)
+                    xi = self.ResultData['Plot']['ROOTObject'].GetBinCenter(ii)
+                    xj = self.ResultData['Plot']['ROOTObject'].GetBinCenter(jj)
+                    dx = xi - xj
+                    dn = ni - nj
+                    x50 = xj + (y50 - nj) / dn * dx
+                    sigma = (xmax - x50)/ 1.3863
+                    break
+
+            print 'n50 ', nj,' at ', xj, ' sigma ',sigma
+            x1 = xmax - sigma*math.sqrt(2*math.log(ymax))    
+            print 'x1 , x1',x1
+            #cut = x1
+            cut = x1 - sigma
+            print 'First Cut: ', cut
+            if cut > cutmax:
+                cut = cutmax
+
+            print '!!!!!!!!!!!!!CUT: ', cut, ' sigma: ',sigma
+            self.ResultData['KeyValueDictPairs']['thrCutBB2Map']['Value'] = cut
+            self.ResultData['KeyList'].append('thrCutBB2Map')
 
         #self.ResultData['Plot']['ROOTObject'] =  HistoGetter.get_histo(self.ParentObject.ParentObject.FileHandle,histname,rocNo=ChipNo).Clone(self.GetUniqueID())
 
@@ -56,13 +101,13 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             #                    self.HasAddressDecodingProblem(column, row)
 
         
-            self.Cut = ROOT.TCutG('bumpWidthCut',2)
-            self.Cut.SetPoint(0,33,-1e9)
-            self.Cut.SetPoint(1,33,+1e9)
-            self.Cut.SetLineWidth(2)
-            self.Cut.SetLineStyle(2)
-            self.Cut.SetLineColor(ROOT.kRed)
-            self.Cut.Draw('PL')
+            self.CutLine = ROOT.TCutG('bumpWidthCut',2)
+            self.CutLine.SetPoint(0,cut,-1e9)
+            self.CutLine.SetPoint(1,cut,+1e9)
+            self.CutLine.SetLineWidth(2)
+            self.CutLine.SetLineStyle(2)
+            self.CutLine.SetLineColor(ROOT.kRed)
+            self.CutLine.Draw('PL')
 
 
 

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/DigChipCurrent/DigChipCurrent.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/DigChipCurrent/DigChipCurrent.py
@@ -25,77 +25,106 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.HistoDict = self.ParentObject.ParentObject.ParentObject.HistoDict
         histname = self.HistoDict.get(self.NameSingle,'DigitalCurrent')
         print 'inside DigChipCurrent ',histname, self.HistoDict
-        object = HistoGetter.get_histo(self.ParentObject.ParentObject.FileHandle, histname, rocNo = ChipNo)
-        self.ResultData['Plot']['ROOTObject']  = object.Clone(self.GetUniqueID())
-        ROOTObject = self.ResultData['Plot']['ROOTObject']
 
-        times = []
-        currents = []
-        title = ROOTObject.GetTitle()
-        seconds = float(title.split(':')[-1])
-        print title,seconds
-        seconds = 0
-        # raw_input()
+        #if self.HistoDict.has_option(self.NameSingle,'DigChipCurrent'):
+        #    histname = self.HistoDict.get(self.NameSingle,'DigitalCurrent')
+        #    object = HistoGetter.get_histo(self.ParentObject.ParentObject.FileHandle, histname, rocNo = ChipNo)
+        #    print 'aqui bla bla bla !!bjkhnkjad', object
+        #self.ResultData['Plot']['ROOTObject']  = object.Clone(self.GetUniqueID())
+        #print 'once again: ',object
+        
+        object = HistoGetter.get_histo(self.ParentObject.ParentObject.FileHandle, histname, rocNo = ChipNo)
+        if object == None: 
+            print 'here inside bla bla bla DigChipCurrent: '
+            
+            self.ResultData['KeyValueDictPairs'] = {
+                'Duration': {
+                    'Value': 'None',
+                    'Label': 'Duration',
+                    'Unit': ''                
+                    },
+                'MaxCurrent': {
+                    'Value': 'None',
+                    'Label': 'max. Current',
+                    'Unit': 'A'
+                    },
+                'MinCurrent': {
+                    'Value': 'None',
+                    'Label': 'min. Current',
+                    'Unit': 'A'
+                    }
+                }
+        else:
+            self.ResultData['Plot']['ROOTObject']  = object.Clone(self.GetUniqueID())
+            ROOTObject = self.ResultData['Plot']['ROOTObject']
+
+            times = []
+            currents = []
+            title = ROOTObject.GetTitle()
+            seconds = float(title.split(':')[-1])
+            print title,seconds
+            seconds = 0
+            # raw_input()
         #print 'bins bla bla: ',self.ResultData['Plot']['ROOTObject'].GetNbinsX()
         
-        for bin in range(1,ROOTObject.GetNbinsX()+1):
-            if ROOTObject.GetBinContent(bin)>0:
-                times.append(ROOTObject.GetXaxis().GetBinCenter(bin)+seconds)
-                currents.append(ROOTObject.GetBinContent(bin))
+            for bin in range(1,ROOTObject.GetNbinsX()+1):
+                if ROOTObject.GetBinContent(bin)>0:
+                    times.append(ROOTObject.GetXaxis().GetBinCenter(bin)+seconds)
+                    currents.append(ROOTObject.GetBinContent(bin))
                 #print bin,times[-1],currents[-1]
-        times = array.array('d',times)
-        currents = array.array('d',currents)
+                    times = array.array('d',times)
+                    currents = array.array('d',currents)
 
-        graph = ROOT.TGraph(len(times),times,currents)
-        graph.SetName(self.GetUniqueID())
-        graph.SetMarkerStyle(7)
-        graph.SetLineStyle(2)
-        graph.SetLineColor(ROOT.kBlue)
-        graph.Draw('AL ')
-        graph.GetXaxis().SetTimeOffset(seconds,'GMT')
-        graph.GetXaxis().SetTitle("Time")
-        graph.GetXaxis().SetTimeDisplay(1)
-            # if max(times) > 30*60:
-        graph.GetXaxis().SetTimeFormat('%H:%M')
-        graph.GetYaxis().SetRangeUser(0,graph.GetYaxis().GetXmax()*1.1)
+            graph = ROOT.TGraph(len(times),times,currents)
+            graph.SetName(self.GetUniqueID())
+            graph.SetMarkerStyle(7)
+            graph.SetLineStyle(2)
+            graph.SetLineColor(ROOT.kBlue)
+            graph.Draw('AL ')
+            graph.GetXaxis().SetTimeOffset(seconds,'GMT')
+            graph.GetXaxis().SetTitle("Time")
+            graph.GetXaxis().SetTimeDisplay(1)
+        # if max(times) > 30*60:
+            graph.GetXaxis().SetTimeFormat('%H:%M')
+            graph.GetYaxis().SetRangeUser(0,graph.GetYaxis().GetXmax()*1.1)
         
 
-        delta = datetime.timedelta(seconds = max(times)-min(times))
-        print str(delta)
-        self.ResultData['KeyValueDictPairs'] = {
-            'Duration': {
-                'Value': '{0}'.format(str(delta)),
-                'Label': 'Duration',
-                'Unit': ''                
-             },
-            'MaxCurrent': {
-                'Value': round(max(currents),3),
-                'Label': 'max. Current',
-                'Unit': 'A'
-            },
-            'MinCurrent': {
-                'Value': round(min(currents),3),
-                'Label': 'min. Current',
-                'Unit': 'A'
-           }
-        }
+            delta = datetime.timedelta(seconds = max(times)-min(times))
+            print str(delta)
+            self.ResultData['KeyValueDictPairs'] = {
+                'Duration': {
+                    'Value': '{0}'.format(str(delta)),
+                    'Label': 'Duration',
+                    'Unit': ''                
+                    },
+                'MaxCurrent': {
+                    'Value': round(max(currents),3),
+                    'Label': 'max. Current',
+                    'Unit': 'A'
+                    },
+                'MinCurrent': {
+                    'Value': round(min(currents),3),
+                    'Label': 'min. Current',
+                    'Unit': 'A'
+                    }
+                }
 
-        self.ResultData['KeyList'] = ['Duration','MinCurrent','MaxCurrent']
-        self.ResultData['Plot']['ROOTGraph'] = graph
+            self.ResultData['KeyList'] = ['Duration','MinCurrent','MaxCurrent']
+            self.ResultData['Plot']['ROOTGraph'] = graph
 
-        if self.ResultData['Plot']['ROOTGraph']:
-            self.Canvas.Clear()
-            self.ResultData['Plot']['ROOTGraph'].SetTitle("")
-            self.ResultData['Plot']['ROOTGraph'].GetXaxis().CenterTitle()
-            self.ResultData['Plot']['ROOTGraph'].GetYaxis().SetTitleOffset(1.5)
-            self.ResultData['Plot']['ROOTGraph'].GetYaxis().CenterTitle()
-            self.ResultData['Plot']['ROOTGraph'].Draw('APL')
-            self.ResultData['Plot']['ROOTObject'] = self.ResultData['Plot']['ROOTGraph']
-        self.ResultData['Plot']['Enabled'] = 1
-        self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
-        print self.GetPlotFileName()
-        self.Title = 'Digital Current'
-        if self.SavePlotFile:
+            if self.ResultData['Plot']['ROOTGraph']:
+                self.Canvas.Clear()
+                self.ResultData['Plot']['ROOTGraph'].SetTitle("")
+                self.ResultData['Plot']['ROOTGraph'].GetXaxis().CenterTitle()
+                self.ResultData['Plot']['ROOTGraph'].GetYaxis().SetTitleOffset(1.5)
+                self.ResultData['Plot']['ROOTGraph'].GetYaxis().CenterTitle()
+                self.ResultData['Plot']['ROOTGraph'].Draw('APL')
+                self.ResultData['Plot']['ROOTObject'] = self.ResultData['Plot']['ROOTGraph']
+                self.ResultData['Plot']['Enabled'] = 1
+                self.ResultData['Plot']['ImageFile'] = self.GetPlotFileName()
+                print self.GetPlotFileName()
+                self.Title = 'Digital Current'
+            if self.SavePlotFile:
             #print 'SavePlotFile', self.SavePlotFile
-            self.Canvas.SaveAs(self.GetPlotFileName())
+                self.Canvas.SaveAs(self.GetPlotFileName())
 


### PR DESCRIPTION

Dear all,

I update the bump bonding method BB2 - now the cut which separates good/missing bumps is calculated for each roc. This changes are relevant for the bare module section. 

I also added a try sentence on AbstractClasses/Helper/HistoGetter.py - When the histo is not know, the status of the histogram is unknown. With this try - the histo is then of type -None- as it should.
 
I check it for the bare module section -
Please let me know if this changes are ok for you, and can be merged 

Thanks for your help
Cheers,

Andrea
