### PR TITLE
check if IV file is there

### DIFF
--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Fulltest.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Fulltest.py
@@ -511,7 +511,7 @@ class TestResult(GeneralTestResult):
 #
 #
             print "IVCURVEDATA ", IVCurveData
-            if IVCurveData['CurrentAtVoltage150V'] != -1 :
+            if IVCurveData['CurrentAtVoltage150V'] != -1 and IVCurveData['IVCurveFilePath'] != ""  :
                 # extract Sensor name
               module = pdb.getFullModule(Row['ModuleID'])
               if module is None:


### PR DESCRIPTION
It seems that moreweb is setting 'CurrentAtVoltage150V' to 0.0 instead of -1 when the IV is not availbale, so we check also the filename in order to decide if IV can be saved to DB