### PR TITLE
Apply grade specified by the user

### DIFF
--- a/Analyse/AbstractClasses/GeneralTestResult.py
+++ b/Analyse/AbstractClasses/GeneralTestResult.py
@@ -335,6 +335,7 @@ class GeneralTestResult(object):
 
     def check_for_manualGrade(self):
         self.RawTestSessionDataPath = os.path.abspath(self.RawTestSessionDataPath)
+        print self.RawTestSessionDataPath
         gradefilenames = glob.glob(self.RawTestSessionDataPath + '/grade.txt')
         grade = ''
         for filename in gradefilenames:
@@ -343,7 +344,7 @@ class GeneralTestResult(object):
             except:
                 warnings.warn('cannot open manual grade file {file}'.format(file=filename))
             grade = gradefile.read()
-            print "we read a manual grade "+str(grade)+" and now we return it"
+            print "Reading a manual grade "+str(grade)+" specified by the user in "+str(filename)
         return grade
             
 

--- a/Analyse/AbstractClasses/GeneralTestResult.py
+++ b/Analyse/AbstractClasses/GeneralTestResult.py
@@ -333,6 +333,20 @@ class GeneralTestResult(object):
             }
             self.ResultData['KeyList'].append('Comment')
 
+    def check_for_manualGrade(self):
+        self.RawTestSessionDataPath = os.path.abspath(self.RawTestSessionDataPath)
+        gradefilenames = glob.glob(self.RawTestSessionDataPath + '/grade.txt')
+        grade = ''
+        for filename in gradefilenames:
+            try:
+                gradefile = open(filename)
+            except:
+                warnings.warn('cannot open manual grade file {file}'.format(file=filename))
+            grade = gradefile.read()
+            print "we read a manual grade "+str(grade)+" and now we return it"
+        return grade
+            
+
     def ReadModuleVersion(self):
         if self.verbose:
             print 'Read configParameters'

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Fulltest.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Fulltest.py
@@ -629,6 +629,10 @@ class TestResult(GeneralTestResult):
         if SubtestMissing:
             grade = 'C'
             Comment += 'Fulltest incomplete, graded C'
+           
+        #adding comment (if any) from manual grading
+        if self.ResultData['SubTestResults']['Grading'].ResultData['KeyValueDictPairs'].has_key('GradeComment'):
+            Comment += self.ResultData['SubTestResults']['Grading'].ResultData['KeyValueDictPairs']['GradeComment']['Value']
 
         # fill final grade and comments
         Comment = Comment.strip().strip('/')

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Grading/Grading.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Grading/Grading.py
@@ -160,6 +160,15 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         if IVGrade > ModuleGrade:
             ModuleGrade = IVGrade
 
+        #if grade was manually specified, apply it
+        GradeComment = ''
+        ManualGrade = self.check_for_manualGrade()
+        print "hello we got a manual grade: "+str(ManualGrade) 
+        if ManualGrade != '':
+            GradeComment = "Grade manually changed from "+str(GradeMapping[ModuleGrade])+" to "+str(GradeMapping[int(ManualGrade)])
+            ModuleGrade =int(ManualGrade)
+            print "ModuleGrade set to "+str(ModuleGrade)
+
         print 'Fulltest Summary:'
         if MissingSubtests:
             print "\x1b[31mMISSING TESTS!\x1b[0m"
@@ -214,6 +223,11 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                 'Value': '{0:1.0f}'.format(nPixelDefectsGradeC),
                 'Label': 'ROCs with Grade C'
             },
+            'GradeComment': {
+                'Value': GradeComment,
+                'Label': 'Grade comment'
+            },
+            
         }
         self.ResultData['HiddenData']['SubGradings'] = SubGradings
         self.ResultData['HiddenData']['MissingSubtests'] = {'Label': 'Missing Subtests', 'Value': '1' if MissingSubtests else '0'}

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Grading/Grading.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Grading/Grading.py
@@ -163,11 +163,10 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         #if grade was manually specified, apply it
         GradeComment = ''
         ManualGrade = self.check_for_manualGrade()
-        print "hello we got a manual grade: "+str(ManualGrade) 
         if ManualGrade != '':
             GradeComment = "Grade manually changed from "+str(GradeMapping[ModuleGrade])+" to "+str(GradeMapping[int(ManualGrade)])
+            print GradeComment
             ModuleGrade =int(ManualGrade)
-            print "ModuleGrade set to "+str(ModuleGrade)
 
         print 'Fulltest Summary:'
         if MissingSubtests:

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XRayHRQualification/Grading/Grading.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XRayHRQualification/Grading/Grading.py
@@ -125,6 +125,14 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             else:
                 MeanNoise = -1
 
+        #if grade was manually specified, apply it
+        GradeComment = ''
+        ManualGrade = self.check_for_manualGrade()
+        if ManualGrade != '':
+            GradeComment = "Grade manually changed from "+str(GradeMapping[ModuleGrade])+" to "+str(GradeMapping[int(ManualGrade)])
+            print GradeComment
+            ModuleGrade =int(ManualGrade)
+                    
         SubGradings['PixelDefects'] = SubGrading
         self.ResultData['KeyValueDictPairs'] = {
             'Module': {
@@ -186,6 +194,10 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             'MeanNoise': {
                 'Value': "{Noise:1.0f}".format(Noise=MeanNoise),
                 'Label': 'Mean Noise'
+            },
+            'GradeComment': {
+                'Value': GradeComment,
+                'Label': 'Grade comment'
             },
         }
 

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XRayHRQualification/XRayHRQualification.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/XRayHRQualification/XRayHRQualification.py
@@ -888,6 +888,8 @@ class TestResult(GeneralTestResult):
         print" ATTRIBUTES", self.Attributes
 #        print" PATTRIBUTES", self.ParentObj.Attributes
         
+        Comment=''
+
         Row = {
             'ModuleID': self.Attributes['ModuleID'],
             'TestDate': self.Attributes['TestDate'],
@@ -913,6 +915,16 @@ class TestResult(GeneralTestResult):
             'Hostname': self.Attributes['Hostname'],
             'Operator': self.Attributes['Operator'],
         }
+
+        #adding comment (if any) from manual grading
+        if self.ResultData['SubTestResults']['Grading'].ResultData['KeyValueDictPairs'].has_key('GradeComment'):
+            Comment += self.ResultData['SubTestResults']['Grading'].ResultData['KeyValueDictPairs']['GradeComment']['Value']
+        
+        # fill final comments
+        Comment = Comment.strip().strip('/')
+        Row.update({
+            'Comments': Comment,
+            })
 
         print 'fill row end'
 
@@ -1300,7 +1312,8 @@ class TestResult(GeneralTestResult):
                         ROCsMoreThanFourPercent,
                         Noise,
                         RelativeModuleFinalResultsPath,
-                        FulltestSubfolder
+                        FulltestSubfolder,
+                        Comments
                         
                     )
                     VALUES (
@@ -1315,8 +1328,8 @@ class TestResult(GeneralTestResult):
                         :ROCsMoreThanFourPercent,
                         :Noise,
                         :RelativeModuleFinalResultsPath,
-                        :FulltestSubfolder
-                        
+                        :FulltestSubfolder,
+                        :Comments
                     )
                     ''', Row)
                 return self.TestResultEnvironmentObject.LocalDBConnectionCursor.lastrowid


### PR DESCRIPTION
This PR provides the possibility to manually change the grade assigned to a module, both in FullTests and in XrayHR tests. The usage is slightly different in the two cases:

create a file named 'grade.txt' inside the following folders:
-  00x_FullTestPxar_xxx folder for fulltests
- Mxxx_XrayQualification_date_timestamp for xray qualifications

The file should contain the grade expressed in numbers ( 1=A, 2=B, 3=C).

A message is shown in the Comment column of the qualification summary reporting both the grade from the analysis and the user grade.