### PR TITLE
BB2 Width Analyse improved

### DIFF
--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBWidth/BareBBWidth.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBWidth/BareBBWidth.py
@@ -11,7 +11,7 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.chipNo = self.ParentObject.Attributes['ChipNo']
         self.cut = 0
         self.ResultData['KeyValueDictPairs']['thrCutBB2Map'] = {'Value': self.cut, 'Label': 'thrCutBB2'}
-
+        
 
     def PopulateResultData(self):
 
@@ -25,49 +25,69 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             self.HistoDict = self.ParentObject.ParentObject.ParentObject.HistoDict
             #print '--- Inside HistoDict BareBBWidth: ', self.HistoDict
             histname = self.HistoDict.get(self.NameSingle,'BareBBWidth')
+            #print 'histname ',  histname
             object = HistoGetter.get_histo(self.ParentObject.ParentObject.FileHandle, histname, rocNo = ChipNo)
-            
+                         
             if object:
-                #print 'bbla'
                 self.ResultData['Plot']['ROOTObject']  = object.Clone(self.GetUniqueID())       
 #
 #  Find PlateauSize cut to define the number of active/missing/inefficient bump-bonding
 #            
-                cutmax = 45
+                #cutmax = 45
                 maxbin = self.ResultData['Plot']['ROOTObject'].GetMaximumBin()                
-                ymax = self.ResultData['Plot']['ROOTObject'].GetBinContent( maxbin )
-                xmax = self.ResultData['Plot']['ROOTObject'].GetBinCenter( maxbin )
-                y50 = 0.5*ymax
-                sigma = self.ResultData['Plot']['ROOTObject'].GetRMS()
-                xi = 0.
-                xj = 0.
-                ni = 0.
-                nj = 0.
-            
-                for ii in range (maxbin,1,-2):
-                    jj = ii -2
-                    if (self.ResultData['Plot']['ROOTObject'].GetBinContent(jj) < y50) and (self.ResultData['Plot']['ROOTObject'].GetBinContent(ii) >= y50):
-                        ni = self.ResultData['Plot']['ROOTObject'].GetBinContent(ii)
-                        nj = self.ResultData['Plot']['ROOTObject'].GetBinContent(jj)
-                        xi = self.ResultData['Plot']['ROOTObject'].GetBinCenter(ii)
-                        xj = self.ResultData['Plot']['ROOTObject'].GetBinCenter(jj)
-                        dx = xi - xj
-                        dn = ni - nj
-                        x50 = xj + (y50 - nj) / dn * dx
-                        sigma = (xmax - x50)/ 1.3863
-                        break
+                ibinxCut0 = maxbin
+                yCut0 = self.ResultData['Plot']['ROOTObject'].GetBinContent( maxbin )
+                #print ' Recalculate the cut using maximun at : ', maxbin
+                #print ' ---- cut: ',cut 
+                #print ' --ycut0 ', yCut0
+                #print ' --ibinxCut0 ', ibinxCut0
+                yCut0Next = yCut0
 
-                    #print 'n50 ', nj,' at ', xj, ' sigma ',sigma
-                x1 = xmax - sigma*math.sqrt(2*math.log(ymax))    
-                cut = x1 - sigma
-                if cut > cutmax:
-                    cut = cutmax
-                if cut < 15:
-                    cut = 35.
+
+                lCheck = True
+                icount = 0
+
+                # going lower
+
+                while ( lCheck and icount < 5): 
+                    #print 'inside condition'
+                    if yCut0 > 0 :
+                        #print 'inside Next Condition running lower'
+                        ibinxCut0Next = ibinxCut0 -1
+                        yCut0Next = self.ResultData['Plot']['ROOTObject'].GetBinContent(ibinxCut0Next)
+                        #print 'yCutNext, xCutNext ',yCut0Next,' -- ',ibinxCut0Next
+                        
+                        # now check 
+                        
+                        yCut0 = yCut0Next
+                        ibinxCut0 = ibinxCut0Next
+                        #++icount
+                    
+                        #print 'Reset yCut0, ibinxCut0 ',yCut0,' -- ',ibinxCut0, icount, ibinxCut0+icount
+                        cut = self.ResultData['Plot']['ROOTObject'].GetBinCenter(ibinxCut0)
+
+                    elif yCut0 == 0:
+                        icount = icount + 1
+                        ibinxCut0Next = ibinxCut0 -1
+                        yCut0Next = self.ResultData['Plot']['ROOTObject'].GetBinContent(ibinxCut0Next)
+                        #print 'condition cero yCutNext, xCutNext ',yCut0Next,' -- ',ibinxCut0Next
+                        yCut0 = yCut0Next
+                        ibinxCut0 = ibinxCut0Next
+                        cut = self.ResultData['Plot']['ROOTObject'].GetBinCenter(ibinxCut0)
+                        #print '---- icount: ', icount, ' ibinxCut0 ', ibinxCut0
+                        
+                    else:
+                        lCheck = False
+                        
+                
+
+                #print 'New Cut at bin : ', ibinxCut0 , ' with entries: ', yCut0, ' x value : ', self.ResultData['Plot']['ROOTObject'].GetBinCenter(ibinxCut0)
 
                 self.ResultData['KeyValueDictPairs']['thrCutBB2Map']['Value'] = cut
                 self.ResultData['KeyList'].append('thrCutBB2Map')
             
+                #print 'THE CUT ',cut
+
                 if self.ResultData['Plot']['ROOTObject']:
                     self.ResultData['Plot']['ROOTObject'].SetTitle("")
                     self.ResultData['Plot']['ROOTObject'].GetXaxis().SetTitle("Column No.")
@@ -75,7 +95,7 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                     self.ResultData['Plot']['ROOTObject'].GetXaxis().CenterTitle()
                     self.ResultData['Plot']['ROOTObject'].GetYaxis().SetTitleOffset(1.5)
                     self.ResultData['Plot']['ROOTObject'].GetYaxis().CenterTitle()
-                    self.ResultData['Plot']['ROOTObject'].Draw()
+                    self.ResultData['Plot']['ROOTObject'].Draw() 
                     
                     self.CutLine = ROOT.TCutG('bumpWidthCut',2)
                     self.CutLine.SetPoint(0,cut,-1e9)

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBWidth/BareBBWidth.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/BareBBWidth/BareBBWidth.py
@@ -83,6 +83,11 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
                 #print 'New Cut at bin : ', ibinxCut0 , ' with entries: ', yCut0, ' x value : ', self.ResultData['Plot']['ROOTObject'].GetBinCenter(ibinxCut0)
 
+                #reset the cut value in casae is negative(!)
+                if (cut < 0):
+                    cut = 20.
+
+
                 self.ResultData['KeyValueDictPairs']['thrCutBB2Map']['Value'] = cut
                 self.ResultData['KeyList'].append('thrCutBB2Map')
             


### PR DESCRIPTION

Dear all,

I modified the analysis of the BB2 histogram to identify better the missing bumps. For some histograms the distribution was not gaussian and the previous sigma cut was not working well. Now the algorithm looks for the empty region of the distribution. Please have a look at the plots in the attchment. Now should be more realible!

This change is important for Desy modules ...

Would be possible to merge it, please?
Cheers,
Andrea

[BareBBWidthBefore.pdf](https://github.com/psi46/MoReWeb/files/61086/BareBBWidthBefore.pdf)
[BareBBWidthAfter.pdf](https://github.com/psi46/MoReWeb/files/61088/BareBBWidthAfter.pdf)

