### PR TITLE
Fixing the missing display of BumpBundingMap and OpParameters in the …

### DIFF
--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/BumpBondingMap/BumpBondingMap.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/BumpBondingMap/BumpBondingMap.py
@@ -9,7 +9,7 @@ class TestResult(TestResultClasses.CMSPixel.QualificationGroup.Fulltest.BumpBond
         self.Name='CMSPixel_QualificationGroup_Fulltest_Chips_Chip_BumpBondingMap_TestResult'
         self.NameSingle='BumpBondingMap'
         self.Attributes['TestedObjectType'] = 'CMSPixel_Module'
-
+        self.ResultData['HiddenData']['SpecialBumpBondingTestName'] = ''
 
     # PopulateResultData is inherited
     

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/Chip.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/Chip.py
@@ -44,6 +44,11 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                         'Order':5,
                     }
                 },
+                {'Key':'BumpBondingMap',
+                    'DisplayOptions':{
+                        'Order':5,
+                    }
+                },                
                 {'Key':'AddressDecoding',
                     'DisplayOptions':{
                         'Order':9,
@@ -83,7 +88,12 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
                  'DisplayOptions':{
                         'Order':1,
                         }
-                 },                
+                 },
+                {'Key':'Grading',
+                    'DisplayOptions':{
+                        'Show':False,
+                    }
+                },
                 ]
             
             

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/OpParameters/OpParameters.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/OpParameters/OpParameters.py
@@ -12,4 +12,8 @@ class TestResult(TestResultClasses.CMSPixel.QualificationGroup.Fulltest.Chips.Ch
     	
         self.Name = 'CMSPixel_QualificationGroup_Fulltest_Chips_Chip_OpParameters_TestResult'
         self.NameSingle = 'OpParameters'
+        self.ResultData['HiddenData']['DacParameters'] = {}
         self.Attributes['TestedObjectType'] = 'CMSPixel_QualificationGroup_Fulltest_ROC'
+
+
+

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/OpParameters/OpParameters.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/OpParameters/OpParameters.py
@@ -24,13 +24,15 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         trimVcalString = ''
         
         # try to get the value from the fulltest logfile
-        if self.ParentObject.ParentObject.ParentObject.trimVcal:
-            vcalTrim = self.ParentObject.ParentObject.ParentObject.trimVcal
-            DacParametersFileName = '{Directory}/dacParameters{trimVcal}_C{ChipNo}.dat'.format(Directory=Directory,ChipNo=self.ParentObject.Attributes['ChipNo'],trimVcal=vcalTrim)
-            if os.path.isfile(DacParametersFileName):
-                foundParametersFile = True
-                trimVcalString = str(vcalTrim)
-
+        try:
+            if self.ParentObject.ParentObject.ParentObject.trimVcal:
+                vcalTrim = self.ParentObject.ParentObject.ParentObject.trimVcal
+                DacParametersFileName = '{Directory}/dacParameters{trimVcal}_C{ChipNo}.dat'.format(Directory=Directory,ChipNo=self.ParentObject.Attributes['ChipNo'],trimVcal=vcalTrim)
+                if os.path.isfile(DacParametersFileName):
+                    foundParametersFile = True
+                    trimVcalString = str(vcalTrim)
+        except:
+            print 'No trim File found'
         # otherwise pick the newest one
         if not foundParametersFile:
             # get all dacParameters files


### PR DESCRIPTION

Dear all,

I modified a bit the BareModule section, since some displaying "dissppear". 

- Now the BumpBondigMap is displayed again - this part inherits from the Fulltest routines. 
- Since for the BareModule test we do not trim the data, a "try" statement was included in the OpParameters.py routine. 
 
This changes are relevant for BareModule analysis - using pxar software. 
Would be possible to merge?
Best Wishes,

Andrea 