### PR TITLE
improve summary for BareModules type C -having missing roc data

### DIFF
--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/BareBBSummary/BareBBSummary.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/BareBBSummary/BareBBSummary.py
@@ -17,48 +17,32 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         self.ResultData['Plot']['ROOTObject'] = ROOT.TH2D(self.GetUniqueID(), "", 8*self.nCols, 0., 8*self.nCols, 2*self.nRows, 0., 2*self.nRows); # mThreshold
 
         for i in self.ParentObject.ResultData['SubTestResults']['Chips'].ResultData['SubTestResults']:
-            ChipTestResultObject = self.ParentObject.ResultData['SubTestResults']['Chips'].ResultData['SubTestResults'][i]
-            histo = ChipTestResultObject.ResultData['SubTestResults']['BareBBMap'].ResultData['Plot']['ROOTObject']
-            print 'histo name inside BareBBSumary: ', histo.GetName()
-            if not histo:
-                print 'cannot get BareBBMap histo for chip ',ChipTestResultObject.Attributes['ChipNo']
-                continue
-            print '---------------------',ChipTestResultObject.Attributes['ChipNo']
-            for col in range(self.nCols): # Columns
-                for row in range(self.nRows): # Rows
-                    #roc = ChipTestResultObject.Attributes['ChipNo'];
-                    #mcol = 52*(roc%8) + col;
-                    #mrow = row;
-                    #
-                    #if ChipTestResultObject.Attributes['ChipNo'] > 7:
-                    #    mcol = 415 - mcol;
-                    #    mrow = 159 - row;
-                    #
-                    #self.ResultData['Plot']['ROOTObject'].SetBinContent(mcol+1, mrow+1, histo.GetBinContent(col + 1, row + 1))
-                    if ChipTestResultObject.Attributes['ChipNo'] < 8:
-                        tmpCol = 8*self.nCols-(ChipTestResultObject.Attributes['ChipNo']*self.nCols+col)
-                        tmpRow = 2*self.nRows-row
-                    else:
-                        tmpCol = (ChipTestResultObject.Attributes['ChipNo']%8*self.nCols+col)+1
-                        tmpRow = row+1
-                    if ChipTestResultObject.Attributes['ChipNo'] < 8:
+            try:
+                ChipTestResultObject = self.ParentObject.ResultData['SubTestResults']['Chips'].ResultData['SubTestResults'][i]
+                histo = ChipTestResultObject.ResultData['SubTestResults']['BareBBMap'].ResultData['Plot']['ROOTObject']
+                print 'histo name inside BareBBSumary: ', histo.GetName()
+                if not histo:
+                    print 'cannot get BareBBMap histo for chip ',ChipTestResultObject.Attributes['ChipNo']
+                    continue
+                print '---------------------',ChipTestResultObject.Attributes['ChipNo']
+                for col in range(self.nCols): # Columns
+                    for row in range(self.nRows): # Rows
+                        if ChipTestResultObject.Attributes['ChipNo'] < 8:
+                            tmpCol = 8*self.nCols-(ChipTestResultObject.Attributes['ChipNo']*self.nCols+col)
+                            tmpRow = 2*self.nRows-row
+                        else:
+                            tmpCol = (ChipTestResultObject.Attributes['ChipNo']%8*self.nCols+col)+1
+                            tmpRow = row+1
+                        if ChipTestResultObject.Attributes['ChipNo'] < 8:
                         #tmpRow += self.nRows
-                        pass
-                    self.ResultData['Plot']['ROOTObject'].SetBinContent(tmpCol, tmpRow, histo.GetBinContent(col + 1, row + 1))
+                            pass
+                        self.ResultData['Plot']['ROOTObject'].SetBinContent(tmpCol, tmpRow, histo.GetBinContent(col + 1, row + 1))
                     
+            except:
+                'No histogram for chip i',i
+
 
         if self.ResultData['Plot']['ROOTObject']:
-            mThresholdMin = 0.
-            mThresholdMax = 255.
-
-            #self.Canvas.SetLinx();
-            #self.Canvas.SetLinY;
-
-            if  self.ResultData['Plot']['ROOTObject'].GetMaximum() < mThresholdMax:
-                mThresholdMax = self.ResultData['Plot']['ROOTObject'].GetMaximum();
-
-            if self.ResultData['Plot']['ROOTObject'].GetMinimum() > mThresholdMin:
-                mThresholdMin = self.ResultData['Plot']['ROOTObject'].GetMinimum();
 
             #self.ResultData['Plot']['ROOTObject'].GetZaxis().SetRangeUser(mThresholdMin,mThresholdMax);
             self.ResultData['Plot']['ROOTObject'].GetXaxis().SetTitle("Column No.");

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/DigChipCurrent/DigChipCurrent.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Chips/Chip/DigChipCurrent/DigChipCurrent.py
@@ -24,7 +24,7 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         ChipNo=self.ParentObject.Attributes['ChipNo']
         self.HistoDict = self.ParentObject.ParentObject.ParentObject.HistoDict
         histname = self.HistoDict.get(self.NameSingle,'DigitalCurrent')
-        print 'inside DigChipCurrent ',histname, self.HistoDict
+        #print 'inside DigChipCurrent ',histname, self.HistoDict
 
         #if self.HistoDict.has_option(self.NameSingle,'DigChipCurrent'):
         #    histname = self.HistoDict.get(self.NameSingle,'DigitalCurrent')

--- a/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Summary1/Summary1.py
+++ b/Analyse/TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Summary1/Summary1.py
@@ -72,9 +72,15 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         for i in chipResults:
             
             if self.ParentObject.testSoftware == 'pxar':
-                DeadPixels = int(i['TestResultObject'].ResultData['SubTestResults']['PixelMap'].ResultData['KeyValueDictPairs']['NDeadPixels']['Value']);
-                totalDeadPixels = totalDeadPixels + DeadPixels;
-                listDefectAlive = i['TestResultObject'].ResultData['SubTestResults']['PixelMap'].ResultData['KeyValueDictPairs']['DeadPixels']['Value'];
+                try:
+                    DeadPixels = int(i['TestResultObject'].ResultData['SubTestResults']['PixelMap'].ResultData['KeyValueDictPairs']['NDeadPixels']['Value']);
+                    totalDeadPixels = totalDeadPixels + DeadPixels;
+                    listDefectAlive = i['TestResultObject'].ResultData['SubTestResults']['PixelMap'].ResultData['KeyValueDictPairs']['DeadPixels']['Value'];
+                except:
+                    print 'No PixelAlive data for Chip ',i['TestResultObject'].Attributes['ChipNo'],' adding 4160 dead pixels!'
+                    #DeadPixels = 4160;
+                    totalDeadPixels = totalDeadPixels + 4160;
+
             else:
                 DeadPixels = int(i['TestResultObject'].ResultData['SubTestResults']['BarePixelMap'].ResultData['KeyValueDictPairs']['NDeadPixels']['Value']);
                 totalDeadPixels = totalDeadPixels + DeadPixels;
@@ -82,8 +88,9 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
             
 
             if not listDefectAlive:
-                print 'Nothing here'
+                print 'pixel alive test without defects'
             else:
+            #if listDefectAlive:
                 #print 'blabla', listDefectAlive
                 combsAlive = []
                 roccombsAlive = {}
@@ -125,7 +132,7 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
         
             if BareModuleInfoFile:
                 for line in BareModuleInfoFile:
-                    print 'line',line
+                    #print 'line',line
                     results  = line.strip().split()
                     if len(results) == 2:
                         Key, ParameterValue = results
@@ -173,27 +180,37 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
         for i in chipResults:
             if self.ParentObject.testSoftware == 'pxar':
-                chipNum = i['TestResultObject'].Attributes['ChipNo'];
-                #print 'DIgCurrent???! ', (i['TestResultObject'].ResultData['SubTestResults']['DigChipCurrent'].ResultData['KeyValueDictPairs']['MaxCurrent']['Value'])
-                valdigChip =  (i['TestResultObject'].ResultData['SubTestResults']['DigChipCurrent'].ResultData['KeyValueDictPairs']['MaxCurrent']['Value'])
-                #print 'DIgCurrent???! ',valdigChip
-                if valdigChip=='None':                    
-                    digCurrentList[chipNum] = 'None'
-                else:
-                    digCurrentList[chipNum] = 1000.*i['TestResultObject'].ResultData['SubTestResults']['DigChipCurrent'].ResultData['KeyValueDictPairs']['MaxCurrent']['Value'];
-                #print 'chipno ',i['TestResultObject'].Attributes['ChipNo']
-                #print 'DIgCurrent???! ', (i['TestResultObject'].ResultData['SubTestResults']['DigChipCurrent'].ResultData['KeyValueDictPairs']['MaxCurrent']['Value']),i
 
-                DeadBumps = int(i['TestResultObject'].ResultData['SubTestResults']['BumpBondingProblems'].ResultData['KeyValueDictPairs']['NDeadBumps']['Value']);
-                totalMissingBumps = totalMissingBumps + DeadBumps;
-                #print 'Inside Chips-loop:',i,totalDeadBumps
-                listDefectBumps = i['TestResultObject'].ResultData['SubTestResults']['BumpBondingProblems'].ResultData['KeyValueDictPairs']['DeadBumps']['Value'];
+                try:
+                    chipNum = i['TestResultObject'].Attributes['ChipNo'];
+                    #print 'DIgCurrent???! ', (i['TestResultObject'].ResultData['SubTestResults']['DigChipCurrent'].ResultData['KeyValueDictPairs']['MaxCurrent']['Value'])
+                    valdigChip =  (i['TestResultObject'].ResultData['SubTestResults']['DigChipCurrent'].ResultData['KeyValueDictPairs']['MaxCurrent']['Value'])
+                    #print 'DIgCurrent???! ',valdigChip
+                    if valdigChip=='None':                    
+                        digCurrentList[chipNum] = 'None'
+                    else:
+                        digCurrentList[chipNum] = 1000.*i['TestResultObject'].ResultData['SubTestResults']['DigChipCurrent'].ResultData['KeyValueDictPairs']['MaxCurrent']['Value'];
+                    #print 'chipno ',i['TestResultObject'].Attributes['ChipNo']
+                    #print 'DIgCurrent???! ', (i['TestResultObject'].ResultData['SubTestResults']['DigChipCurrent'].ResultData['KeyValueDictPairs']['MaxCurrent']['Value']),i
 
-                #Check if BB2 Histogram exist:
-                if (globaluseBB2Map=='yes'):
-                    listDefectBumpsBB2 = i['TestResultObject'].ResultData['SubTestResults']['BareBBMap'].ResultData['KeyValueDictPairs']['MissingBumps']['Value'];
-                    DeadBumpsBB2 = int(i['TestResultObject'].ResultData['SubTestResults']['BareBBMap'].ResultData['KeyValueDictPairs']['NMissingBumps']['Value']);
-                    totalMissingBumpsBB2 = totalMissingBumpsBB2 + DeadBumpsBB2;
+                    DeadBumps = int(i['TestResultObject'].ResultData['SubTestResults']['BumpBondingProblems'].ResultData['KeyValueDictPairs']['NDeadBumps']['Value']);
+                    totalMissingBumps = totalMissingBumps + DeadBumps;
+                    #print 'Inside Chips-loop :',chipNum,' : ',totalDeadBumps
+                    listDefectBumps = i['TestResultObject'].ResultData['SubTestResults']['BumpBondingProblems'].ResultData['KeyValueDictPairs']['DeadBumps']['Value'];
+
+                    #Check if BB2 Histogram exist:
+                    if (globaluseBB2Map=='yes'):
+                        listDefectBumpsBB2 = i['TestResultObject'].ResultData['SubTestResults']['BareBBMap'].ResultData['KeyValueDictPairs']['MissingBumps']['Value'];
+                        DeadBumpsBB2 = int(i['TestResultObject'].ResultData['SubTestResults']['BareBBMap'].ResultData['KeyValueDictPairs']['NMissingBumps']['Value']);
+                        totalMissingBumpsBB2 = totalMissingBumpsBB2 + DeadBumpsBB2;
+
+                except:
+                    print 'No BB-Histogram is found Chip: ', i['TestResultObject'].Attributes['ChipNo']
+                    #DeadBumps = 4160;
+                    totalMissingBumps = totalMissingBumps + 4160;
+                    #DeadBumpsBB2 = 4160;
+                    totalMissingBumpsBB2 = totalMissingBumpsBB2 + 4160;
+
 
             else:
                 chipNum = i['TestResultObject'].Attributes['ChipNo'];
@@ -207,8 +224,9 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
 
             if not listDefectBumps:
-                print 'Nothing here'
+                print 'No list of DefectBumps'
             else:
+            #if listDefectBumps:
                 #print 'blabla', listDefectBumps
                 combs = []
                 roccombs = {}
@@ -226,7 +244,7 @@ class TestResult(AbstractClasses.GeneralTestResult.GeneralTestResult):
 
             if (globaluseBB2Map=='yes'):
                 if not listDefectBumpsBB2:
-                    print 'No BB2 Method is used'
+                    print 'listDefectBB2 empty'
                 else:
                     combsBB2 = []
                     roccombsBB2 = {}


### PR DESCRIPTION
Dear Pirmin,

I introduce some changes to avoid the crash for BareModule analysis on raw-pxar-data with no ROC-data. 

If no roc data is present, then the number of dead pixels and bump bonding will be increased to 4160 (routine TestResultClasses/CMSPixel/QualificationGroup/BareModuleTest/Summary1/Summary1.py). This will guarantee that the grading becomes C - this step is performed later in the DB - 

Nevertheless I could not manage to fix a warning message:

File "/home/vargas/psi/dataBase/morewebMar01_2016/MoReWeb/Analyse/AbstractClasses/GeneralTestResult.py", line 511, in PopulateAllData
    self.PopulateResultData()
  File "/home/vargas/psi/dataBase/morewebMar01_2016/MoReWeb/Analyse/TestResultClasses/CMSPixel/QualificationGroup/Fulltest/Chips/Chip/Grading/Grading.py", line 73, in PopulateResultData
    if self.ParentObject.ResultData['SubTestResults']['BB4'].ResultData['Plot']['ROOTObject']:
KeyError: 'BB4'

which does not interfere to the results, but I could not understand why appears...
Please let me know if this changes are ok .... 

Best Wishes,
Andrea
